### PR TITLE
Add metadata

### DIFF
--- a/meta/libraries.json
+++ b/meta/libraries.json
@@ -5,7 +5,7 @@
         "Dave Abrahams",
         "Kevlin Henney"
     ],
-    "description": "Polymorphic and lexical casts.",
+    "description": "Polymorphic casts.",
     "category": [
         "Miscellaneous",
         "String"


### PR DESCRIPTION
Adds metadata automatically generated from the website's record, and then removes mention of lexical_cast. I did it in two stages to make it clear what I was doing.
