### PR TITLE
Correct spelling of "suppress"

### DIFF
--- a/test/implicit_cast.cpp
+++ b/test/implicit_cast.cpp
@@ -29,7 +29,7 @@ int main()
     type<foo> f = check_return(boost::implicit_cast<foo>("hello"));
     type<long> z = check_return(boost::implicit_cast<long>(foo("hello")));
 
-    // warning supression:
+    // warning suppression:
     (void)x;
     (void)f;
     (void)z;


### PR DESCRIPTION
"Suppress" is spelled with two P's, even in British English.