### PR TITLE
boost::assertion_failed trapped assertions, and subsequent bad casts …

### DIFF
--- a/test/polymorphic_cast_test.cpp
+++ b/test/polymorphic_cast_test.cpp
@@ -25,12 +25,17 @@
 static bool expect_assertion = false;
 static int assertion_failed_count = 0;
 
+//assertion handler throws it to exit like assert, but to be able to catch it and stop
+//usage: BOOST_TEST_THROWS( function_with_assert(), expected_assertion );
+struct expected_assertion {};
+
 // BOOST_ASSERT custom handler
 void boost::assertion_failed( char const * expr, char const * function, char const * file, long line )
 {
     if( expect_assertion )
     {
         ++assertion_failed_count;
+        throw expected_assertion();
     }
     else
     {
@@ -278,7 +283,7 @@ static void test_polymorphic_downcast_fail()
     int old_count = assertion_failed_count;
     expect_assertion = true;
 
-    boost::polymorphic_downcast<Derived*>( base ); // should assert
+    BOOST_TEST_THROWS( boost::polymorphic_downcast<Derived*>( base ), expected_assertion ); // should assert
 
     BOOST_TEST_EQ( assertion_failed_count, old_count + 1 );
     expect_assertion = false;
@@ -293,7 +298,7 @@ static void test_polymorphic_pointer_downcast_builtin_fail()
     int old_count = assertion_failed_count;
     expect_assertion = true;
 
-    boost::polymorphic_pointer_downcast<Derived>( base ); // should assert
+    BOOST_TEST_THROWS( boost::polymorphic_pointer_downcast<Derived>( base ), expected_assertion ); // should assert
 
     BOOST_TEST_EQ( assertion_failed_count, old_count + 1 );
     expect_assertion = false;
@@ -308,7 +313,7 @@ static void test_polymorphic_pointer_downcast_boost_shared_fail()
     int old_count = assertion_failed_count;
     expect_assertion = true;
 
-    boost::polymorphic_pointer_downcast<Derived>( base ); // should assert
+    BOOST_TEST_THROWS( boost::polymorphic_pointer_downcast<Derived>( base ), expected_assertion ); // should assert
 
     BOOST_TEST_EQ( assertion_failed_count, old_count + 1 );
     expect_assertion = false;
@@ -323,7 +328,7 @@ static void test_polymorphic_pointer_downcast_std_shared_fail()
     int old_count = assertion_failed_count;
     expect_assertion = true;
 
-    boost::polymorphic_pointer_downcast<Derived>( base ); // should assert
+    BOOST_TEST_THROWS( boost::polymorphic_pointer_downcast<Derived>( base ), expected_assertion ); // should assert
 
     BOOST_TEST_EQ( assertion_failed_count, old_count + 1 );
     expect_assertion = false;
@@ -338,7 +343,7 @@ static void test_polymorphic_pointer_downcast_intrusive_fail()
     int old_count = assertion_failed_count;
     expect_assertion = true;
 
-    boost::polymorphic_pointer_downcast<Derived>( base ); // should assert
+    BOOST_TEST_THROWS( boost::polymorphic_pointer_downcast<Derived>( base ), expected_assertion); // should assert
 
     BOOST_TEST_EQ( assertion_failed_count, old_count + 1 );
     expect_assertion = false;


### PR DESCRIPTION
boost::assertion_failed trapped asserts, so bad casts were executed anyway. Now it throws exceptions for assert-like behavior.