### PR TITLE
Try to fix the documentation build

### DIFF
--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -32,7 +32,7 @@ boostbook standalone
      ;
 
 ###############################################################################
-alias boostdoc : standalone ;
+alias boostdoc : conversion_lib ;
 explicit boostdoc ;
 alias boostrelease ;
 explicit boostrelease ;


### PR DESCRIPTION
I think boostdoc is depending on the wrong target. Not sure if this will work, but worth a go?