### PR TITLE
Fix the documentation redirect

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<meta http-equiv="refresh" content="0; url=../../doc/html/conversion.html">
+<meta http-equiv="refresh" content="0; url=../../doc/html/conversion_lib.html">
 <title>Boost.Conversion</title>
 <style>
   body {
@@ -26,7 +26,7 @@
 <body>
   <p>
     Automatic redirection failed, please go to
-    <a href="../../doc/html/conversion.html">../../doc/html/conversion.html</a>
+    <a href="../../doc/html/conversion_lib.html">../../doc/html/conversion_lib.html</a>
   </p>
   <p>
     &copy; 2014 Antony Polukhin


### PR DESCRIPTION
#11 fixed the documentation build, but the redirect is going to the wrong URL. You can see the documentation at:

http://www.boost.org/doc/libs/develop/doc/html/conversion_lib.html