### PR TITLE
[CMake] Add minimal cmake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 #       and the interface is likely to change in the future
 
 cmake_minimum_required( VERSION 3.5 )
-project( boost-conversion LANGUAGES CXX )
+project( BoostConversion LANGUAGES CXX )
 
 add_library( boost_conversion INTERFACE )
 add_library( Boost::conversion ALIAS boost_conversion )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Copyright 2019 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt
+#
+# NOTE: CMake support for Boost.Conversion is currently experimental at best
+#       and the interface is likely to change in the future
+
+cmake_minimum_required( VERSION 3.5 )
+project( boost-conversion LANGUAGES CXX )
+
+add_library( boost_conversion INTERFACE )
+add_library( Boost::conversion ALIAS boost_conversion )
+
+target_include_directories( boost_conversion INTERFACE include )
+
+target_link_libraries( boost_conversion
+    INTERFACE
+        Boost::assert
+        Boost::config
+        Boost::smart_ptr
+        Boost::throw_exception
+        Boost::type_traits
+        Boost::typeof
+)


### PR DESCRIPTION
This cmake file just provides the minimal infrastructure necessary, such that other libraries can get a sensible result from calling


    add_subdirectory( <path-to-boost_conversion> )
    target_link_libraries( <my_lib> PUBLIC Boost::conversion )


provided that all direct and indirect dependencies are also being added via `add_subdirectory` (which can e.g happen via globbing expression).

More information:

    * https://groups.google.com/forum/#!topic/boost-developers-archive/9ZdrVbAn1aU


Of course the file can be extended to e.g. build and run tests and support installation, but that is out of scope for this particular PR.

Please note that this is largely orthogonal to the recent addition to b2/boost by peter dimov, which is concerned with providing cmake config files for "classic" boost installations via b2.
