### PR TITLE
[CMake] Add boost core to dependency list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ target_link_libraries( boost_conversion
     INTERFACE
         Boost::assert
         Boost::config
+        Boost::core
         Boost::smart_ptr
         Boost::throw_exception
         Boost::type_traits


### PR DESCRIPTION
Used in  boost/polymorphic_cast.hpp since https://github.com/boostorg/conversion/commit/58c33270a2761d51d40a8b94912afa96c6b8617e