### PR TITLE
Use relative URL for redirect in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<meta http-equiv="refresh" content="0; url=https://www.boost.org/doc/libs/master/doc/html/conversion.html">
+<meta http-equiv="refresh" content="0; url=../../doc/html/conversion.html">
 <title>Boost.Conversion</title>
 <style>
   body {
@@ -28,7 +28,7 @@
 <body>
   <p>
     Automatic redirection failed, please go to
-    <a href="https://www.boost.org/doc/libs/master/doc/html/conversion.html">https://www.boost.org/doc/libs/master/doc/html/conversion.html</a>
+    <a href="../../doc/html/conversion.html">../../doc/html/conversion.html</a>
   </p>
   <p>
     &copy; Antony Polukhin, 2014-2023

--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
  Distributed under the Boost Software License,
  Version 1.0. (See accompanying file LICENSE_1_0.txt
  or copy at http://boost.org/LICENSE_1_0.txt)
+
+boost-no-inspect
 -->
 <html>
 <head>


### PR DESCRIPTION
Makes redirect in index.html consistent with other boost libraries. This also works when browsing HTML files locally (release archive).