### PR TITLE
Remove mentions of lexical_cast from docs

### DIFF
--- a/doc/conversion.qbk
+++ b/doc/conversion.qbk
@@ -30,8 +30,7 @@ The Conversion Library improves program safety and clarity by performing
 otherwise messy conversions. It includes cast-style function templates designed 
 to complement the C++ Standard's built-in casts.
 
-To reduce coupling, particularly to standard library IOStreams, 
-the Boost Conversion Library is supplied by several headers:
+To reduce coupling, the Boost Conversion Library is supplied by several headers:
 
 # The [@boost:boost/polymorphic_cast.hpp boost/polymorphic_cast.hpp] header
   provides [link polymorphic_cast `polymorphic_cast<>`] and
@@ -42,8 +41,6 @@ the Boost Conversion Library is supplied by several headers:
   [link polymorphic_pointer_cast `polymorphic_pointer_downcast<>`]
 # The [@boost:boost/implicit_cast.hpp boost/implicit_cast.hpp] header provides `implicit_cast<>` 
   to perform implicit casts only (no down-cast, no void*->T*, no U->T if T has only explicit constructors for U).
-# The [@boost:boost/lexical_cast.hpp boost/lexical_cast.hpp] header 
-  provides [@boost:doc/libs/release/libs/lexical_cast/ `lexical_cast<>`] general literal text conversions, such as an `int` represented as a `string`, or vice-versa. 
 
 [endsect]
 


### PR DESCRIPTION
lexical_cast isn't a part of Boost.Conversion, it's part of Boost.Lexical_Cast