### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/conversion
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -7,13 +7,13 @@ import project ;
 
 project /boost/conversion
     : common-requirements
-        <source>/boost/assert//boost_assert
-        <source>/boost/config//boost_config
-        <source>/boost/core//boost_core
-        <source>/boost/smart_ptr//boost_smart_ptr
-        <source>/boost/throw_exception//boost_throw_exception
-        <source>/boost/type_traits//boost_type_traits
-        <source>/boost/typeof//boost_typeof
+        <library>/boost/assert//boost_assert
+        <library>/boost/config//boost_config
+        <library>/boost/core//boost_core
+        <library>/boost/smart_ptr//boost_smart_ptr
+        <library>/boost/throw_exception//boost_throw_exception
+        <library>/boost/type_traits//boost_type_traits
+        <library>/boost/typeof//boost_typeof
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/conversion

--- a/build.jam
+++ b/build.jam
@@ -11,11 +11,8 @@ project /boost/conversion
     : common-requirements
         <library>/boost/assert//boost_assert
         <library>/boost/config//boost_config
-        <library>/boost/core//boost_core
         <library>/boost/smart_ptr//boost_smart_ptr
         <library>/boost/throw_exception//boost_throw_exception
-        <library>/boost/type_traits//boost_type_traits
-        <library>/boost/typeof//boost_typeof
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -5,19 +5,22 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/assert//boost_assert
+    /boost/config//boost_config
+    /boost/smart_ptr//boost_smart_ptr
+    /boost/throw_exception//boost_throw_exception ;
+
 project /boost/conversion
     : common-requirements
-        <library>/boost/assert//boost_assert
-        <library>/boost/config//boost_config
-        <library>/boost/smart_ptr//boost_smart_ptr
-        <library>/boost/throw_exception//boost_throw_exception
         <include>include
     ;
 
 explicit
-    [ alias boost_conversion ]
+    [ alias boost_conversion : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_conversion test ]
     ;
 
 call-if : boost-library conversion
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,26 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/conversion
+    : common-requirements
+        <source>/boost/assert//boost_assert
+        <source>/boost/config//boost_config
+        <source>/boost/core//boost_core
+        <source>/boost/smart_ptr//boost_smart_ptr
+        <source>/boost/throw_exception//boost_throw_exception
+        <source>/boost/type_traits//boost_type_traits
+        <source>/boost/typeof//boost_typeof
+        <include>include
+    ;
+
+explicit
+    [ alias boost_conversion ]
+    [ alias all : boost_conversion test ]
+    ;
+
+call-if : boost-library conversion
+    ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -5,10 +5,11 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
 
+require-b2 5.0.1 ;
+import-search /boost/config/checks ;
+import config : requires ;
 import testing ;
 import feature ;
-
-import ../../config/checks/config : requires ;
 
 project
     : requirements

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -13,6 +13,7 @@ import feature ;
 
 project
     : requirements
+        <library>/boost/conversion//boost_conversion
         [ requires cxx11_decltype ]
         # default to all warnings on:
         <warnings>all


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.